### PR TITLE
fixed error: mongoNetwork error by editing the config.mongodb.urls to point to config.mongodb.url

### DIFF
--- a/src/database/database.js
+++ b/src/database/database.js
@@ -3,7 +3,7 @@
 import mongoose from 'mongoose';
 import config from '../../config/config.js';
 
-const MONGODB_URI = config.mongodb.urls || 'mongodb://127.0.0.1/blog';
+const MONGODB_URI = config.mongodb.url || 'mongodb://127.0.0.1/blog';
 
 export default async function connectMongoDB() {
     try {

--- a/src/middleware/authenticate.js
+++ b/src/middleware/authenticate.js
@@ -20,7 +20,7 @@ export const authenticateToken = async (req, res, next) => {
 
     if (!accessToken) {
         if (!refreshToken) {
-            return res.status(HTTP_STATUS.FORBIDDEN).json({ message: 'Access token is required' });
+            return res.status(HTTP_STATUS.FORBIDDEN).redirect('/login');
         }
         await refreshTokens(req, res, next);  // Pass `next` to proceed after refreshing tokens.
         return;


### PR DESCRIPTION
### Error: MongoNetworkError
```bash
error message: MongoNetworkError: connect ECONNREFUSED 127.0.0.1:27017
```
The initial config.mongodb.urls did not exist in the config file. 
- changed to config.mongodb.url
- Redirected to /login if access Token is invalid/unavailable

